### PR TITLE
Removed the COVERALLS_REPO_TOKEN environment variable.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ nuget:
   project_feed: false
   disable_publish_on_pr: true
 
-environment:
-  COVERALLS_REPO_TOKEN:
-    secure: vETv5DkQGqHNKitDtA5zhh5bwTDxLv7u//a1sA83zP3gU1xQsu7MAxpNIDMQPQ4k
-
 cache:
   - packages -> **\packages.config
 


### PR DESCRIPTION
It is stored in AppVeyor directly to hopefully get PRs to get through it without failing.