### PR TITLE
Fix unit tests that fail if the current culture does not use periods a decimal separator

### DIFF
--- a/tests/FakerDotNet.Tests/Fakers/AddressFakerTests.cs
+++ b/tests/FakerDotNet.Tests/Fakers/AddressFakerTests.cs
@@ -304,7 +304,7 @@ namespace FakerDotNet.Tests.Fakers
         {
             A.CallTo(() => _fakerContainer.Number.Between(0, 180)).Returns(31.82743772556281);
             
-            Assert.AreEqual("-58.1725622744", _addressFaker.Latitude());
+            Assert.AreEqual((-58.1725622744).ToString("#.##########"), _addressFaker.Latitude());
         }
 
         [Test]
@@ -312,7 +312,7 @@ namespace FakerDotNet.Tests.Fakers
         {
             A.CallTo(() => _fakerContainer.Number.Between(0, 360)).Returns(23.344516179048668);
             
-            Assert.AreEqual("-156.655483821", _addressFaker.Longitude());
+            Assert.AreEqual((-156.655483821).ToString("#.##########"), _addressFaker.Longitude());
         }
 
         [Test]


### PR DESCRIPTION
Fixes issue #70 where AddressFaker longitude and latitude unit tests fail if the current culture decimal separator is not a period.