### PR TITLE
Using SetCulture attribute in some tests

### DIFF
--- a/src/FakerDotNet/Fakers/AddressFaker.cs
+++ b/src/FakerDotNet/Fakers/AddressFaker.cs
@@ -134,12 +134,12 @@ namespace FakerDotNet.Fakers
 
         public string Latitude()
         {
-            return $"{_fakerContainer.Number.Between(0, 180) - 90:#.##########}";
+            return $"{_fakerContainer.Number.Between(0, 180) - 90}";
         }
 
         public string Longitude()
         {
-            return $"{(_fakerContainer.Number.Between(0, 360) - 180):#.##########}";
+            return $"{_fakerContainer.Number.Between(0, 360) - 180}";
         }
 
         public string FullAddress()

--- a/tests/FakerDotNet.Tests/Fakers/AddressFakerTests.cs
+++ b/tests/FakerDotNet.Tests/Fakers/AddressFakerTests.cs
@@ -274,19 +274,39 @@ namespace FakerDotNet.Tests.Fakers
         }
 
         [Test]
-        public void Latitude_returns_a_latitude()
+        [SetCulture("en-GB")]
+        public void Latitude_returns_a_latitude_when_culture_is_en_GB()
         {
             A.CallTo(() => _fakerContainer.Number.Between(0, 180)).Returns(31.82743772556281);
             
-            Assert.AreEqual((-58.1725622744).ToString("#.##########"), _addressFaker.Latitude());
+            Assert.AreEqual("-58.1725622744372", _addressFaker.Latitude());
+        }
+        
+        [Test]
+        [SetCulture("de-DE")]
+        public void Latitude_returns_a_latitude_when_culture_is_de_DE()
+        {
+            A.CallTo(() => _fakerContainer.Number.Between(0, 180)).Returns(31.82743772556281);
+            
+            Assert.AreEqual("-58,1725622744372", _addressFaker.Latitude());
         }
 
         [Test]
-        public void Longitude_returns_a_longitude()
+        [SetCulture("en-GB")]
+        public void Longitude_returns_a_longitude_when_culture_is_en_GB()
         {
             A.CallTo(() => _fakerContainer.Number.Between(0, 360)).Returns(23.344516179048668);
             
-            Assert.AreEqual((-156.655483821).ToString("#.##########"), _addressFaker.Longitude());
+            Assert.AreEqual("-156.655483820951", _addressFaker.Longitude());
+        }
+        
+        [Test]
+        [SetCulture("de-DE")]
+        public void Longitude_returns_a_longitude_when_culture_is_de_DE()
+        {
+            A.CallTo(() => _fakerContainer.Number.Between(0, 360)).Returns(23.344516179048668);
+            
+            Assert.AreEqual("-156,655483820951", _addressFaker.Longitude());
         }
 
         [Test]


### PR DESCRIPTION
When we are running tests that convert `double` or `decimal` values to strings it will return different values depending on what the current culture is. For example:

- `en-GB` -> `"1.23"`
- `de-DE` -> `"1,23"`

So I have added the `[SetCulture("en-GB")]` attribute to ensure that we get a return value for a single culture.
I added extra tests that also check using the `de-DE` culture to make sure that it is working as expected.